### PR TITLE
Fix Azure login error in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.__clientidsecretname__ }}
-          tenant-id: ${{ secrets.__tenantidsecretname__ }}
-          subscription-id: ${{ secrets.__subscriptionidsecretname__ }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp


### PR DESCRIPTION
Update the Azure login step in the GitHub Actions workflow to include necessary credentials.

* Add `client-id`, `tenant-id`, and `subscription-id` to the `Login to Azure` step
* Reference `client-id`, `tenant-id`, and `subscription-id` from GitHub secrets

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Saphyre-Solutions-LLC/TelePrompt-Authentication/pull/7?shareId=df79c2dc-daaa-4345-bda5-875090ffa4b1).